### PR TITLE
TYPE=MyISAM deprecated in mysql 5.0 and removed in 5.5, replace with ENGINE=MyISAM

### DIFF
--- a/create_tables.sql
+++ b/create_tables.sql
@@ -97,7 +97,7 @@ CREATE TABLE info (
 
 CREATE TABLE metars (
   metar varchar(255) NOT NULL default '',
-  timestamp timestamp(14) NOT NULL,
+  timestamp timestamp NOT NULL,
   station varchar(4) NOT NULL default '',
   PRIMARY KEY  (station),
   UNIQUE KEY station (station)


### PR DESCRIPTION
This change is necessary for create_tables.sql to work in MySQL 5.5 or later.
